### PR TITLE
Fixed mass_fuzz.sh

### DIFF
--- a/evaluation/mass_fuzz.sh
+++ b/evaluation/mass_fuzz.sh
@@ -53,7 +53,7 @@ echo "we are launching!"
 PROCESS_NUM=$1
 for POC in $INPUTDIR/*
 do
-     if [$PROCESS_NUM -le 0]
+     if [ $PROCESS_NUM -le 0 ]
      then 
           break
      elif test -d $POC

--- a/evaluation/mass_fuzz_afl.sh
+++ b/evaluation/mass_fuzz_afl.sh
@@ -51,7 +51,7 @@ echo "we are launching!"
 PROCESS_NUM=$1
 for POC in $INPUTDIR/*
 do
-     if [$PROCESS_NUM -le 0]
+     if [ $PROCESS_NUM -le 0 ]
      then 
           break
      elif test -d $POC


### PR DESCRIPTION
Bash if-statements need a space before and after brackets.